### PR TITLE
fix: Add unit to CSQL_PROXY_MAX_SIGTERM_DELAY environment variable to be compatible with go duration

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -743,7 +743,7 @@ func (s *updateState) applyContainerSpec(p *cloudsqlapi.AuthProxyWorkload, c *co
 	}
 	if p.Spec.AuthProxyContainer.MaxSigtermDelay != nil &&
 		*p.Spec.AuthProxyContainer.MaxSigtermDelay != 0 {
-		s.addProxyContainerEnvVar(p, "CSQL_PROXY_MAX_SIGTERM_DELAY", fmt.Sprintf("%d", *p.Spec.AuthProxyContainer.MaxSigtermDelay))
+		s.addProxyContainerEnvVar(p, "CSQL_PROXY_MAX_SIGTERM_DELAY", fmt.Sprintf("%ds", *p.Spec.AuthProxyContainer.MaxSigtermDelay))
 	}
 
 	return

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -696,7 +696,7 @@ func TestProxyCLIArgs(t *testing.T) {
 				"CSQL_PROXY_PROMETHEUS":                  "true",
 				"CSQL_PROXY_QUOTA_PROJECT":               "qp",
 				"CSQL_PROXY_MAX_CONNECTIONS":             "10",
-				"CSQL_PROXY_MAX_SIGTERM_DELAY":           "20",
+				"CSQL_PROXY_MAX_SIGTERM_DELAY":           "20s",
 				"CSQL_PROXY_IMPERSONATE_SERVICE_ACCOUNT": "sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com",
 				"CSQL_PROXY_QUIET":                       "true",
 				"CSQL_PROXY_STRUCTURED_LOGS":             "true",


### PR DESCRIPTION
## Expected Behavior
`maxSigtermDelay` should be pass as a duration to the cloud sql proxy container to be taken into account

## Actual Behavior
`maxSigtermDelay` is configured as an environment variable with a number value type whereas the cloud sql proxy expects a duration (https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/a2070bf1c6be9996945229b1b1e0a98ce9b36dd5/cmd/root.go#L468)
A number without unit is considered as 0 for a duration (tested here: https://pkg.go.dev/time#ParseDuration).

## Steps to Reproduce the Problem

n/a

## Specifications

- Version: 1.4.4
- Platform: GKE



Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR